### PR TITLE
Generalize the found content text.

### DIFF
--- a/world/admin.py
+++ b/world/admin.py
@@ -1,7 +1,7 @@
 from django.contrib.gis import admin
 from embed_video.admin import AdminVideoMixin
 from solo.admin import SingletonModelAdmin
-from .models import TextSnugget, EmbedSnugget, SnuggetSection, SnuggetSubSection, TsunamiZone, ImpactZoneData, ImpactZone, ExpectedGroundShaking, Infrastructure, InfrastructureGroup, InfrastructureCategory, RecoveryLevels, Location
+from .models import TextSnugget, EmbedSnugget, SnuggetSection, SnuggetSubSection, TsunamiZone, ImpactZoneData, ImpactZone, ExpectedGroundShaking, Infrastructure, InfrastructureGroup, InfrastructureCategory, RecoveryLevels, Location, SiteSettings
 
 admin.site.register(SnuggetSection, admin.ModelAdmin)
 admin.site.register(SnuggetSubSection, admin.ModelAdmin)
@@ -64,4 +64,5 @@ admin.site.register(InfrastructureCategory, admin.ModelAdmin)
 admin.site.register(RecoveryLevels, admin.ModelAdmin)
 
 # To make the UI more general
+admin.site.register(SiteSettings, SingletonModelAdmin)
 admin.site.register(Location, SingletonModelAdmin)

--- a/world/migrations/0059_auto_20151204_0034.py
+++ b/world/migrations/0059_auto_20151204_0034.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('world', '0058_auto_20151202_2311'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='location',
+            name='emergency_management_link',
+            field=models.URLField(default='http://www.fema.gov', help_text='A link to your local office of emergency management.'),
+        ),
+        migrations.AddField(
+            model_name='location',
+            name='evacuation_routes_link',
+            field=models.URLField(default='', blank=True, help_text='A link to website that can help people find an evacuation route'),
+        ),
+    ]

--- a/world/migrations/0060_merge.py
+++ b/world/migrations/0060_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('world', '0059_auto_20151204_0034'),
+        ('world', '0059_auto_20151202_2347'),
+    ]
+
+    operations = [
+    ]

--- a/world/migrations/0061_auto_20151204_1833.py
+++ b/world/migrations/0061_auto_20151204_1833.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('world', '0060_merge'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteSettings',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True, serialize=False)),
+                ('about_text', models.TextField(default='Information about your organization goes here.', help_text='Describe the data and the agencies that it came from.')),
+                ('contact_email', models.EmailField(max_length=254, default='contact@youremail.com', help_text='Put a contact email for the maintainer of this site here.')),
+                ('site_url', models.URLField(default='http://www.example.com', help_text='Put the URL to this site here.')),
+                ('site_title', models.CharField(max_length=50, default='Your Title Here!')),
+                ('site_description', models.CharField(max_length=200, default='A disaster preparedness website', help_text='A small, catchy description for this site.')),
+            ],
+            options={
+                'verbose_name': 'Site Settings',
+            },
+        ),
+        migrations.RemoveField(
+            model_name='location',
+            name='about_text',
+        ),
+        migrations.RemoveField(
+            model_name='location',
+            name='contact_email',
+        ),
+        migrations.RemoveField(
+            model_name='location',
+            name='site_description',
+        ),
+        migrations.RemoveField(
+            model_name='location',
+            name='site_title',
+        ),
+        migrations.RemoveField(
+            model_name='location',
+            name='site_url',
+        ),
+    ]

--- a/world/models.py
+++ b/world/models.py
@@ -33,6 +33,8 @@ class Location(SingletonModel):
     disaster_name = models.CharField(max_length=50, default="some disaster", help_text="Something like 'a tsunami', 'an earthquake', 'a fire'")
     disaster_description = models.TextField(default="A natural disaster could strike your area at any time.", help_text="A description of what we are trying to help people prepare for.")
     
+    evacuation_routes_link = models.URLField(default="", blank=True, help_text="A link to website that can help people find an evacuation route")
+    emergency_management_link = models.URLField(default="http://www.fema.gov", help_text="A link to your local office of emergency management.")
     def __unicode__(self):
         return u"Location Information"
 

--- a/world/models.py
+++ b/world/models.py
@@ -22,19 +22,64 @@ SNUGGET_TYPES = (
 
 TSUNAMIZONE_ID = 1
 
-class Location(SingletonModel):
-    area_name = models.CharField(max_length=100, default="the affected area", help_text="Describe the entire area that this app covers, e.g. 'Oregon' or 'Missoula County'.")
-    about_text = models.TextField(default="Information about your organization goes here.", help_text="Describe the data and the agencies that it came from.")
-    contact_email = models.EmailField(default="contact@youremail.com", help_text="Put a contact email for the maintainer of this site here.")
-    site_url = models.URLField(default="http://www.example.com", help_text="Put the URL to this site here.")
-    site_title = models.CharField(max_length=50, default="Your Title Here!")
-    site_description = models.CharField(max_length=200, default="A disaster preparedness website", help_text="A small, catchy description for this site.")
 
-    disaster_name = models.CharField(max_length=50, default="some disaster", help_text="Something like 'a tsunami', 'an earthquake', 'a fire'")
-    disaster_description = models.TextField(default="A natural disaster could strike your area at any time.", help_text="A description of what we are trying to help people prepare for.")
+class SiteSettings(SingletonModel):
+    """A singleton model to represent site-wide settings."""
+    about_text = models.TextField(
+        default="Information about your organization goes here.",
+        help_text="Describe the data and the agencies that it came from."
+    )
+    contact_email = models.EmailField(
+        default="contact@youremail.com",
+        help_text="Put a contact email for the maintainer of this site here."
+    )
+    site_url = models.URLField(
+        default="http://www.example.com",
+        help_text="Put the URL to this site here."
+    )
+    site_title = models.CharField(
+        max_length=50,
+        default="Your Title Here!"
+    )
+    site_description = models.CharField(
+        max_length=200,
+        default="A disaster preparedness website",
+        help_text="A small, catchy description for this site."
+    )
+
+    def __unicode__(self):
+        return u"Site Settings"
+
+    class Meta:
+        verbose_name = "Site Settings"
+
+
+class Location(SingletonModel):
+    """A singleton model to represent the location covered by this website's data"""
+    area_name = models.CharField(
+        max_length=100,
+        default="the affected area",
+        help_text="Describe the entire area that this app covers, e.g. 'Oregon' or 'Missoula County'."
+    )
+    disaster_name = models.CharField(
+        max_length=50,
+        default="some disaster",
+        help_text="Something like 'a tsunami', 'an earthquake', 'a fire'"
+    )
+    disaster_description = models.TextField(
+        default="A natural disaster could strike your area at any time.", 
+        help_text="A description of what we are trying to help people prepare for."
+    )
+    evacuation_routes_link = models.URLField(
+        default="",
+        blank=True,
+        help_text="A link to website that can help people find an evacuation route"
+    )
+    emergency_management_link = models.URLField(
+        default="http://www.fema.gov",
+        help_text="A link to your local office of emergency management."
+    )
     
-    evacuation_routes_link = models.URLField(default="", blank=True, help_text="A link to website that can help people find an evacuation route")
-    emergency_management_link = models.URLField(default="http://www.fema.gov", help_text="A link to your local office of emergency management.")
     def __unicode__(self):
         return u"Location Information"
 

--- a/world/templates/found_content.html
+++ b/world/templates/found_content.html
@@ -262,8 +262,12 @@
     </div>
     <div class="small-10 medium-5 column">
       <h4 class="caps">Know Your Routes</h4>
-      <p>Make sure your family and friends know where to gather after the earthquake and how to get there. You'll need a reconnection plan. Do you cross a bridge on your way to school or work? It could be unsafe to cross after an earthquake. Do you need an evacuation route? If you're in the tsunami zone, you do. <a href="http://www.oregongeology.org/tsuclearinghouse/">Find your route.</a></p>
-      <p>Also be aware that some major roads won't be safe or passable during and after an earthquake. Contact your local public works department or <a href="http://www.oregon.gov/omd/oem/pages/index.aspx">Office of Emergency Management</a> in advance to find out which routes could potentially be impassable in your area.</p>
+      <p>Make sure your family and friends know where to gather after {{ location.disaster_name }} and how to get there. You'll need a reconnection plan. Do you cross a bridge on your way to school or work? It could be unsafe to cross after {{ location.disaster_name }}. Do you need an evacuation route? 
+      {% if location.evacuation_routes_link %}
+        <a href="{{ location.evacuation_routes_link }}">Find your route.</a>
+      {% endif %}
+      </p>
+      <p>Also be aware that some major roads won't be safe or passable during and after {{ location.disaster_name }}. Contact your local public works department or <a href="{{ location.emergency_management_link }}">Office of Emergency Management</a> in advance to find out which routes could potentially be impassable in your area.</p>
     </div>
 
     <div class="small-2 medium-1 column">

--- a/world/templates/geek_box.html
+++ b/world/templates/geek_box.html
@@ -1,8 +1,8 @@
 <div id="geek-box" class="row vert-pad-medium">
   <div class="small-12 medium-6 columns">
       <h6 class="caps">How does it work?</h6>
-      <p>This site is designed to help people prepare for disasters that can occur in their area. {{ SiteSettings.about_text }}</p>
-      <p>Have questions? Click <a href="mailto:{{ SiteSettings.contact_email }}">here</a> to email the maintainers.</p>
+      <p>This site is designed to help people prepare for disasters that can occur in their area. {{ settings.about_text }}</p>
+      <p>Have questions? Click <a href="mailto:{{ settings.contact_email }}">here</a> to email the maintainers.</p>
   </div>
   <div class="small-12 medium-6 columns">
       <h6 class="caps">Who made this?</h6>

--- a/world/templates/geek_box.html
+++ b/world/templates/geek_box.html
@@ -1,8 +1,8 @@
 <div id="geek-box" class="row vert-pad-medium">
   <div class="small-12 medium-6 columns">
       <h6 class="caps">How does it work?</h6>
-      <p>This site is designed to help people prepare for disasters that can occur in their area. {{ location.about_text }}</p>
-      <p>Have questions? Click <a href="mailto:{{ location.contact_email }}">here</a> to email the maintainers.</p>
+      <p>This site is designed to help people prepare for disasters that can occur in their area. {{ SiteSettings.about_text }}</p>
+      <p>Have questions? Click <a href="mailto:{{ SiteSettings.contact_email }}">here</a> to email the maintainers.</p>
   </div>
   <div class="small-12 medium-6 columns">
       <h6 class="caps">Who made this?</h6>

--- a/world/templates/index.html
+++ b/world/templates/index.html
@@ -4,11 +4,11 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta property="og:url" content="{{ SiteSettings.site_url }}"/>
-  <meta property="og:title" content="{{ SiteSettings.site_description }}">
+  <meta property="og:url" content="{{ settings.site_url }}"/>
+  <meta property="og:title" content="{{ settings.site_description }}">
   <meta property="og:description" content="{{ location.disaster_description }} Enter your location for a personalized report on your risks and how to prepare.">
 
-  <title>{{ SiteSettings.site_title }}</title>
+  <title>{{ settings.site_title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link type="text/css" rel="stylesheet" href="{% static 'css/normalize.css' %}">
   <link type="text/css" rel="stylesheet" href="{% static 'css/foundation.css' %}">
@@ -30,8 +30,8 @@
 </head>
 <body>
   <div class="row">
-    <h3 class="caps underline">{{ SiteSettings.site_title }}</h3>
-    <h5 class="caps">{{ SiteSettings.site_description }}</h5>
+    <h3 class="caps underline">{{ settings.site_title }}</h3>
+    <h5 class="caps">{{ settings.site_description }}</h5>
     <p>{{ location.disaster_description }} Enter your location for a personalized report on your risks and how to prepare.</p>
   </div>
 
@@ -71,7 +71,7 @@
       <div class="small-12 medium-5 column">
         <h4 class="caps underline">What’s Your Disaster Recovery Story?</h4>
         <h5 class="caps">The Moment</h5>
-        <p>{{ SiteSettings.site_title }} predicts what you will experience during {{ location.disaster_name }} based on your location in {{ location.area_name }}.</p>
+        <p>{{ settings.site_title }} predicts what you will experience during {{ location.disaster_name }} based on your location in {{ location.area_name }}.</p>
 
         <h5 class="caps">Recovery Time</h5>
         <p>Find estimates for how long  your neighborhood will take to reconnect to basic services, such as water and power.</p>

--- a/world/templates/index.html
+++ b/world/templates/index.html
@@ -4,11 +4,11 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta property="og:url" content="{{ location.site_url }}"/>
-  <meta property="og:title" content="{{ location.site_description }}">
+  <meta property="og:url" content="{{ SiteSettings.site_url }}"/>
+  <meta property="og:title" content="{{ SiteSettings.site_description }}">
   <meta property="og:description" content="{{ location.disaster_description }} Enter your location for a personalized report on your risks and how to prepare.">
 
-  <title>{{ location.site_title }}</title>
+  <title>{{ SiteSettings.site_title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link type="text/css" rel="stylesheet" href="{% static 'css/normalize.css' %}">
   <link type="text/css" rel="stylesheet" href="{% static 'css/foundation.css' %}">
@@ -30,8 +30,8 @@
 </head>
 <body>
   <div class="row">
-    <h3 class="caps underline">{{ location.site_title }}</h3>
-    <h5 class="caps">{{ location.site_description }}</h5>
+    <h3 class="caps underline">{{ SiteSettings.site_title }}</h3>
+    <h5 class="caps">{{ SiteSettings.site_description }}</h5>
     <p>{{ location.disaster_description }} Enter your location for a personalized report on your risks and how to prepare.</p>
   </div>
 
@@ -71,7 +71,7 @@
       <div class="small-12 medium-5 column">
         <h4 class="caps underline">What’s Your Disaster Recovery Story?</h4>
         <h5 class="caps">The Moment</h5>
-        <p>{{ location.site_title }} predicts what you will experience during {{ location.disaster_name }} based on your location in {{ location.area_name }}.</p>
+        <p>{{ SiteSettings.site_title }} predicts what you will experience during {{ location.disaster_name }} based on your location in {{ location.area_name }}.</p>
 
         <h5 class="caps">Recovery Time</h5>
         <p>Find estimates for how long  your neighborhood will take to reconnect to basic services, such as water and power.</p>

--- a/world/templates/supply-kit.html
+++ b/world/templates/supply-kit.html
@@ -75,4 +75,4 @@
       </div>
   {% endif %}
 {% endfor %}
-      <p>For more information on making your kit, check out these emergency supply lists from <a href="http://www.opb.org/news/series/unprepared/a-visual-guide-to-emergency-supplies-everyone-needs/">OPB</a> and <a href="http://www.redcross.org/prepare/location/home-family/get-kit">American Red Cross</a>.</p>
+      <p>For more information on making your kit, check out these emergency supply lists from <a href="http://www.opb.org/news/series/unprepared/a-visual-guide-to-emergency-supplies-everyone-needs/">Oregon Public Broadcasting</a> and <a href="http://www.redcross.org/prepare/location/home-family/get-kit">American Red Cross</a>.</p>

--- a/world/test_location_model.py
+++ b/world/test_location_model.py
@@ -5,12 +5,10 @@ class LocationModelTestCase(TestCase):
   def setUp(self):
     Location.objects.create(
       area_name="Melindaville",
-      about_text="Some sample text",
-      contact_email="foo@bar.com",
-      site_url="http://www.whatever.com:4949/stuff.aspx?whatever",
-      site_description="This is an example disaster website",
       disaster_name="a zombie attack",
-      disaster_description="Zombies are real, you know."
+      disaster_description="Zombies are real, you know.",
+      evacuation_routes_link="http://default.com",
+      emergency_management_link="http://www.fema.gov"
     )
 
   def testObjectFormation(self):

--- a/world/test_sitesettings_model.py
+++ b/world/test_sitesettings_model.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+from .models import SiteSettings
+
+class SiteSettingsModelTestCase(TestCase):
+  def setUp(self):
+    SiteSettings.objects.create(    
+      about_text="Some sample text",
+      contact_email="foo@bar.com",
+      site_url="http://www.whatever.com:4949/stuff.aspx?whatever",
+      site_description="This is an example disaster website"
+    )
+
+  def testObjectFormation(self):
+    """The SiteSettings object is created properly as a singleton"""
+    settings = SiteSettings.objects.get()
+    self.assertEqual(settings.__unicode__(), "Site Settings")

--- a/world/views.py
+++ b/world/views.py
@@ -71,5 +71,6 @@ def app_view(request):
     # if not, we'll still serve up the same template without data
     else:
         return render(request, 'index.html', {
-            'location': location
+            'location': location,
+            'settings': settings
             })

--- a/world/views.py
+++ b/world/views.py
@@ -1,10 +1,11 @@
 from django.shortcuts import render
 from math import floor
-from .models import Snugget, Location
+from .models import Snugget, Location, SiteSettings
 
 
 def app_view(request):
     location = Location.get_solo()
+    settings = SiteSettings.get_solo()
 
     # if user submitted lat/lng, find our snuggets and send them to our template
     if 'lat' and 'lng' in request.GET:
@@ -61,6 +62,7 @@ def app_view(request):
                 
             return render(request, template, {
                 'location': location,
+                'settings': settings,
                 'data': snugget_content, 
                 'section_width': section_width,
                 'wrapper_width': wrapper_width


### PR DESCRIPTION
I added a few more things under the location object.

We might want to break it into two objects, one for site details (like the URL, title and contact link) and one for location information (like the disaster name and emergency preparedness links). What do you think?
