### PR TITLE
Fix subsection headers showing up repeatedly

### DIFF
--- a/world/templates/found_content.html
+++ b/world/templates/found_content.html
@@ -40,11 +40,14 @@
         {% else %}
           <div class="content disaster-content" id="{{group}}">
         {% endif %}
-          {% for section, snuggets in hazard.sections.items %}
+          {% for section, sub_sections in hazard.sections.items %}
             <div class="snugget-text">
               <h4 class="section-title">{{ section }}</h4>
-              {% for snugget in snuggets %}
-                {% show_snugget snugget %}
+              {% for sub_section, snuggets in sub_sections.items %}
+                <h5>{{ sub_section }}</h5>
+                {% for snugget in snuggets %}
+                  {% show_snugget snugget %}
+                {% endfor %}
               {% endfor %}
             </div>
           {% endfor %}
@@ -81,6 +84,6 @@
       <h4>Important Links</h4>
       <p>Important Links about community resources go here.</p>
     </div>
-  </div> 
+  </div>
 
 {% endblock main-content %}

--- a/world/templates/snugget_text.html
+++ b/world/templates/snugget_text.html
@@ -1,5 +1,4 @@
 {% block snugget-content %}
-  <h5>{{ snugget.sub_section.name }}</h5>
   {% if snugget.sub_section.name == "Intensity" %}
     <div class="intensity">
       <div class="intensity-meter">

--- a/world/views.py
+++ b/world/views.py
@@ -26,10 +26,12 @@ def app_view(request):
                         for text_snugget in values:
                             if not text_snugget.image:
                                 text_snugget.dynamic_image = make_icon(text_snugget.percentage)
-                            if text_snugget.section in sections:
-                                sections[text_snugget.section].append(text_snugget)
+                            if not text_snugget.section in sections:
+                                sections[text_snugget.section] = {}
+                            if text_snugget.sub_section in sections[text_snugget.section]:
+                                sections[text_snugget.section][text_snugget.sub_section].append(text_snugget)
                             else:
-                                sections[text_snugget.section] = [text_snugget]
+                                sections[text_snugget.section][text_snugget.sub_section] = [text_snugget]
 
                         data[key] = {
                             'heading': heading,


### PR DESCRIPTION
I noticed that if I had multiple snuggets under the same section and sub_section, the subsection header would show up repeatedly.

That's because I didn't build the data structure in the view to account for that happening.
