### PR TITLE
[REVIEW] Fire dial problems

### DIFF
--- a/cascadiaprepared/static/css/app.css
+++ b/cascadiaprepared/static/css/app.css
@@ -244,6 +244,7 @@ h5 {
 
 .tabs-content > .content.active {
   display:inline-block;
+  width: 100%;
 }
 
 .tabs dd.active a, .tabs .tab-title.active a {

--- a/world/fire_dial.py
+++ b/world/fire_dial.py
@@ -122,4 +122,4 @@ def make_icon(percentage):
 
     # Look for {0} and {1} above to see where the arrow path goes.
     # The third argument is a salt for the marker element IDs, which must be unique per page.
-    return dial.format(transform_x, transform_y, randint(0, 9999))
+    return dial.format(transform_x, transform_y, randint(0, 99999))

--- a/world/fire_dial.py
+++ b/world/fire_dial.py
@@ -1,4 +1,5 @@
 from math import sin, cos, radians
+from random import randint
 
 dial = """<svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -9,17 +10,15 @@ dial = """<svg
    width="105px"
    height="65px"
    viewBox="0 0 354.00001 179.16412"
-   id="svg4816"
    version="1.1">
-  <defs
-     id="defs4818">
+  <defs>
 
 <!-- the arrowhead -->
     <marker
        orient="auto"
        refY="0"
        refX="0"
-       id="arrowhead"
+       id="arrowhead-{2}"
        style="overflow:visible">
       <path
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
@@ -82,21 +81,18 @@ X=448.2 is lined up with the inside-right
 This gives a length range from 164.4 to 165.8.  Hrm....
 -->
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:4.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;marker-end:url(#arrowhead)"
-       d="M 282.4,420.6 {0}, {1}"
-       id="path7305" />
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:4.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;marker-end:url(#arrowhead-{2})"
+       d="M 282.4,420.6 {0}, {1}"/>
 
 <!-- this path is the outline -->
     <path
        d="m 107.07684,422.57976 a 175,175 0 0 1 175.00001,-174.99999 175,175 0 0 1 174.99999,175 l -175,0 z"
-       id="path5990"
        style="fill:#000000;fill-opacity:0;stroke:#2c2c2c;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 
 
 <!-- this path is the centre point that the arrow comes out of -->
     <path
        style="fill:#2c2c2c;fill-opacity:1;stroke:#2c2c2c;stroke-width:4;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path4870"
        d="m 264.12235,422.00333 a 18.15621,18.15621 0 0 1 18.15621,-18.15621 18.15621,18.15621 0 0 1 18.15621,18.15621 l -18.15621,0 z" />
 
   </g>
@@ -125,4 +121,5 @@ def make_icon(percentage):
     transform_y = y_center - y
 
     # Look for {0} and {1} above to see where the arrow path goes.
-    return dial.format(transform_x, transform_y)
+    # The third argument is a salt for the marker element IDs, which must be unique per page.
+    return dial.format(transform_x, transform_y, randint(0, 9999))

--- a/world/templates/snugget_text.html
+++ b/world/templates/snugget_text.html
@@ -1,5 +1,5 @@
 {% block snugget-content %}
-  {% if snugget.sub_section.name == "Intensity" %}
+  {% if snugget.image or snugget.dynamic_image %}
     <div class="intensity">
       <div class="intensity-meter">
         {% if snugget.image %}


### PR DESCRIPTION
The new snuggets showed up two problems with my generated fire dial icons:
1. I had been assuming that they would always appear in a sub-section named intensity
2. I had only had one per page, which means that there were no two ids inside the generated svgs that were the same. As soon as you have more than one per page, the id for the arrowhead marker is not unique anymore, which is invalid HTML. So I added a salt for the marker ids to make them unique per generated svg, and removed unneeded ids inside the svgs themselves to avoid further trouble.
