### PR TITLE
Before forking MissoulaReady, put the data zip back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 secure_settings.py
 
 # Data directory full of binary or large data sets we don't need in a code repository.
-# data/
+ data/
 # Temp directories made by the importer
 disasterinfosite/data/reprojected/
 disasterinfosite/data/simplified/


### PR DESCRIPTION
We can undo this in the forked branch if we're going to still make changes to the data.
