### PR TITLE
Now handles 3D shapefiles

### DIFF
--- a/import.py
+++ b/import.py
@@ -230,9 +230,9 @@ def detectGeometryType(sf, stem):
   except stopIteration:
     print("No valid geometries found in", stem, "- please check the shapefile")
     exit()
-  if shapeType == 5:
+  if shapeType == 5 or shapeType == 15:
     return "MultiPolygon"
-  elif shapeType == 3:
+  elif shapeType == 3 or shapeType == 13:
     print("WARNING:", stem, "has a linear geometry, and this application currently only handles polygons properly")
     return "MultiLineString"
   else:

--- a/import.py
+++ b/import.py
@@ -235,6 +235,12 @@ def detectGeometryType(sf, stem):
   elif shapeType == 3 or shapeType == 13:
     print("WARNING:", stem, "has a linear geometry, and this application currently only handles polygons properly")
     return "MultiLineString"
+  elif shapeType == 1 or shapeType == 8 or shapeType == 11 or shapeType == 18:
+    print("WARNING:", stem, "has a point geometry, and this application currently only handles polygons properly")
+    return "MultiPoint"
+  elif shapeType > 20:
+  	print("Support for Multipart geometries is not implemented yet")
+  	exit()
   else:
     print("Geometry field type ", shapeType, "unrecognised")
 # the list of valid geometry field type codes is at


### PR DESCRIPTION
Well that was easier than I expected!  It turned out that we don’t need any special handling for PolygonZ geometry types - we can just get away with telling GDAL to treat it as a MultiPolygon.

While figuring that out I also added some more informative error messages for the shapefile types we can’t [yet] handle.
