### PR TITLE
Add model translation infrastructure, but don't turn it on by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,4 +239,7 @@ Upload photos to show in a photo gallery in the search results, under Past Event
 +###### Data Overview Images
 In the box at the bottom of every page, there's a section called 'Quick Data Overview'. That's where these will show up, as links that open in a new tab or window. The link_text field is what the link says, like 'Earthquakes: Distance from a Fault', and you can upload the appropriate image here.
 
-
+# Supporting multiple languages
+To support a multi-language site, you need to provide message files for the Django views, by the usual means of `makemessages` and `compilemessages`.
+In addition, there are many bits of text that are configurable through Django Admin. To translate those, uncomment the relevant lines in settings.py, admin.py and translation.py. Then run `makemigrations` and `migrate`. You should then have fields for multiple languages exposed in Django Admin.
+For more information, see the [Django-ModelTranslation docs](http://django-modeltranslation.readthedocs.io/en/latest/index.html)

--- a/disasterinfosite/admin.py
+++ b/disasterinfosite/admin.py
@@ -15,6 +15,13 @@ from .actions import export_as_csv_action
 
 admin.site.register(SnuggetSection, admin.ModelAdmin)
 admin.site.register(SnuggetSubSection, admin.ModelAdmin)
+
+# To use translatable models and see them in DjangoAdmin, use the following 3 lines instead.
+# admin.site.register(ShapefileGroup, TranslationAdmin)
+# admin.site.register(PastEventsPhoto, TranslationAdmin)
+# admin.site.register(DataOverviewImage, TranslationAdmin)
+
+# Use the next three lines if you don't want to translate these models into other languages in Django Admin.
 admin.site.register(ShapefileGroup, admin.ModelAdmin)
 admin.site.register(PastEventsPhoto, admin.ModelAdmin)
 admin.site.register(DataOverviewImage, admin.ModelAdmin)
@@ -81,6 +88,21 @@ admin.site.register(User, UserAdmin)
 class GeoNoEditAdmin(admin.GeoModelAdmin):
     modifiable = False
 
+# Uncomment the next lines if you want to translate fields in DjangoAdmin to different languages.
+# admin.site.register(ImportantLink, TranslationAdmin)
+# class SiteSettingsAdmin(SingletonModelAdmin, TranslationAdmin):
+#     pass
+# admin.site.register(SiteSettings, SiteSettingsAdmin)
+
+# class LocationAdmin(SingletonModelAdmin, TranslationAdmin):
+#     pass
+# admin.site.register(Location, LocationAdmin)
+
+# class SupplyKitAdmin(SingletonModelAdmin, TranslationAdmin):
+#     pass
+# admin.site.register(SupplyKit, SupplyKitAdmin)
+
+# Keep this block as-is if you don't want to translate these models into other languages in DjangoAdmin.
 admin.site.register(ImportantLink, admin.ModelAdmin)
 admin.site.register(SiteSettings, SingletonModelAdmin)
 admin.site.register(Location, SingletonModelAdmin)

--- a/disasterinfosite/settings.py
+++ b/disasterinfosite/settings.py
@@ -26,6 +26,7 @@ else:
 
 # Application definition
 INSTALLED_APPS = (
+   # If you want to translate Django models, uncomment this. 'modeltranslation',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -58,6 +59,12 @@ WSGI_APPLICATION = 'disasterinfosite.wsgi.application'
 LOCALE_PATHS = [os.path.join(BASE_DIR, 'locale')]
 LANGUAGE_CODE = 'en-us'
 USE_L10N = True
+# Uncomment to translate Django models.
+# gettext = lambda s: s
+# LANGUAGES = (
+#     ('en-us', gettext('English')),
+#     ('es', gettext('Spanish'))
+# )
 
 USE_I18N = True
 TIME_ZONE = 'UTC'

--- a/disasterinfosite/translation.py
+++ b/disasterinfosite/translation.py
@@ -1,0 +1,32 @@
+# Uncomment if you want to translate Django models.
+
+# from modeltranslation.translator import register, translator, TranslationOptions
+# from .models import SiteSettings, Location, SupplyKit, ImportantLink, ShapefileGroup, PastEventsPhoto, DataOverviewImage
+
+# @register(SiteSettings)
+# class SiteSettingsTranslationOptions(TranslationOptions):
+#     fields = ('about_text', 'site_title', 'site_description', 'intro_text', 'who_made_this')
+
+# @register(Location)
+# class LocationTranslationOptions(TranslationOptions):
+#   fields = ('area_name', 'community_leaders')
+
+# @register(SupplyKit)
+# class SupplyKitTranslationOptions(TranslationOptions):
+#   fields = ('text',)
+
+# @register(ImportantLink)
+# class ImportantLinkTranslationOptions(TranslationOptions):
+#   fields = ('title',)
+
+# @register(ShapefileGroup)
+# class ShapefileGroupTranslationOptions(TranslationOptions):
+#   fields = ('display_name',)
+
+# @register(PastEventsPhoto)
+# class PastEventsPhotoTranslationOptions(TranslationOptions):
+#   fields = ('caption',)
+
+# @register(DataOverviewImage)
+# class DataOverviewImageTranslationOptions(TranslationOptions):
+#   fields = ('link_text',)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests==2.13.0
 static3==0.7.0
 django-solo==1.1.2
 Pillow==4.1.0
+django-modeltranslation==0.12.1


### PR DESCRIPTION
This is because if you turn it on, it generates a lot of fields in Django Admin that would be extra and confusing in a single-language app.