### PR TITLE
Enable snugget translations and add display names for sections and subsections

### DIFF
--- a/disasterinfosite/admin.py
+++ b/disasterinfosite/admin.py
@@ -12,16 +12,18 @@ from .models import EmbedSnugget, TextSnugget, SnuggetSection, SnuggetSubSection
 ######################################################
 from .models import ShapefileGroup, PastEventsPhoto, DataOverviewImage, UserProfile
 from .actions import export_as_csv_action
+# To turn translation on from modeltranslation.admin import TranslationAdmin
 
-admin.site.register(SnuggetSection, admin.ModelAdmin)
-admin.site.register(SnuggetSubSection, admin.ModelAdmin)
-
-# To use translatable models and see them in DjangoAdmin, use the following 3 lines instead.
+# To use translatable models and see them in DjangoAdmin, use the following 5 lines instead.
+#admin.site.register(SnuggetSection, TranslationAdmin)
+#admin.site.register(SnuggetSubSection, TranslationAdmin)
 # admin.site.register(ShapefileGroup, TranslationAdmin)
 # admin.site.register(PastEventsPhoto, TranslationAdmin)
 # admin.site.register(DataOverviewImage, TranslationAdmin)
 
 # Use the next three lines if you don't want to translate these models into other languages in Django Admin.
+admin.site.register(SnuggetSection, admin.ModelAdmin)
+admin.site.register(SnuggetSubSection, admin.ModelAdmin)
 admin.site.register(ShapefileGroup, admin.ModelAdmin)
 admin.site.register(PastEventsPhoto, admin.ModelAdmin)
 admin.site.register(DataOverviewImage, admin.ModelAdmin)
@@ -48,7 +50,8 @@ class SnuggetAdmin(admin.ModelAdmin):
         return "Undefined"
 
 
-class TextAdmin(SnuggetAdmin):
+# if you want to translate text snuggets: class TextAdmin(SnuggetAdmin, TranslationAdmin):
+class TextAdmin(SnuggetAdmin)
     fieldsets = SnuggetAdmin.fieldsets + ((None, {
         'fields': ('content',),
         }),

--- a/disasterinfosite/admin.py
+++ b/disasterinfosite/admin.py
@@ -51,7 +51,7 @@ class SnuggetAdmin(admin.ModelAdmin):
 
 
 # if you want to translate text snuggets: class TextAdmin(SnuggetAdmin, TranslationAdmin):
-class TextAdmin(SnuggetAdmin)
+class TextAdmin(SnuggetAdmin):
     fieldsets = SnuggetAdmin.fieldsets + ((None, {
         'fields': ('content',),
         }),

--- a/disasterinfosite/migrations/0001_initial.py
+++ b/disasterinfosite/migrations/0001_initial.py
@@ -106,7 +106,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, primary_key=True, auto_created=True)),
                 ('name', models.CharField(max_length=50)),
-                ('display_name', models.CharField(max_length=50)),
+                ('display_name', models.CharField(max_length=50, default="")),
                 ('order_of_appearance', models.IntegerField(help_text='The order, from left to right, in which you would like this group to appear, when applicable.', default=0)),
                 ('likely_scenario_title', models.CharField(max_length=80, blank=True)),
                 ('likely_scenario_text', models.TextField(blank=True)),
@@ -125,7 +125,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('name', models.CharField(max_length=50)),
-                ('display_name', models.CharField(blank=True, help_text='The name to show for this section', max_length=50)),
+                ('display_name', models.CharField(default="", help_text='The name to show for this section', max_length=50)),
                 ('order_of_appearance', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the tab. 0 is at the top."))
             ],
         ),
@@ -134,7 +134,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('name', models.CharField(max_length=50)),
-                ('display_name', models.CharField(blank=True, help_text='The name to show for this section', max_length=50)),
+                ('display_name', models.CharField(default="", help_text='The name to show for this section', max_length=50)),
                 ('order_of_appearance', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."))
             ],
         ),

--- a/disasterinfosite/migrations/0001_initial.py
+++ b/disasterinfosite/migrations/0001_initial.py
@@ -125,6 +125,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('name', models.CharField(max_length=50)),
+                ('display_name', models.CharField(blank=True, help_text='The name to show for this section', max_length=50)),
                 ('order_of_appearance', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the tab. 0 is at the top."))
             ],
         ),
@@ -133,6 +134,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('name', models.CharField(max_length=50)),
+                ('display_name', models.CharField(blank=True, help_text='The name to show for this section', max_length=50)),
                 ('order_of_appearance', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."))
             ],
         ),

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -6,6 +6,8 @@ from embed_video.fields import EmbedVideoField
 from model_utils.managers import InheritanceManager
 from solo.models import SingletonModel
 from django.core.files.storage import FileSystemStorage
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
 
 SNUG_TEXT = 0
 SNUG_AUDIO = 1
@@ -151,7 +153,7 @@ class ShapeManager(models.GeoManager):
 
 class ShapefileGroup(models.Model):
     name = models.CharField(max_length=50)
-    display_name = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=50, default="")
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order, from left to right, in which you would like this group to appear, when applicable."
@@ -220,7 +222,7 @@ class SnuggetType(models.Model):
 
 class SnuggetSection(models.Model):
     name = models.CharField(max_length=50)
-    display_name = models.CharField(max_length=50, default=name)
+    display_name = models.CharField(max_length=50, help_text="The name to show for this section", default="")
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the tab. 0 is at the top."
@@ -232,7 +234,7 @@ class SnuggetSection(models.Model):
 
 class SnuggetSubSection(models.Model):
     name = models.CharField(max_length=50)
-    display_name = models.CharField(max_length=50, default=name)
+    display_name = models.CharField(max_length=50, help_text="The name to show for this section", default="")
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -220,6 +220,7 @@ class SnuggetType(models.Model):
 
 class SnuggetSection(models.Model):
     name = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=50, default=name)
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the tab. 0 is at the top."
@@ -231,6 +232,7 @@ class SnuggetSection(models.Model):
 
 class SnuggetSubSection(models.Model):
     name = models.CharField(max_length=50)
+    display_name = models.CharField(max_length=50, default=name)
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the section. 0 is at the top. These can be in different sections or mutually exclusive, hence the non-unique values."
@@ -238,6 +240,13 @@ class SnuggetSubSection(models.Model):
 
     def __str__(self):
         return self.name
+
+@receiver(pre_save, sender=SnuggetSection)
+@receiver(pre_save, sender=SnuggetSection)
+@receiver(pre_save, sender=ShapefileGroup)
+def default_display_name(sender, instance, *args, **kwargs):
+    if not instance.display_name:
+        instance.display_name = instance.name
 
 
 class Snugget(models.Model):

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -42,17 +42,16 @@
           {% for section, sub_sections in hazard.sections.items %}
             <div class="snugget-text">
               <div class="section-icon section-icon--dynamic section-icon--{{ section }}">
-                <h2 class="caps section-title">{{ section }}</h2>
+                <h2 class="caps section-title">{{ section.display_name }}</h2>
               </div>
               <div class="section-content">
                 {% for sub_section, snuggets in sub_sections.items %}
-                  <h3>{{ sub_section }}</h3>
+                  <h3>{{ sub_section.display_name }}</h3>
                   {% for snugget in snuggets %}
                     {% show_snugget snugget %}
                   {% endfor %}
                 {% endfor %}
-                {% trans "Past Events" as past_events %}
-                {% if section.name == past_events and hazard.photos %}
+                {% if section.name == "Past Events" and hazard.photos %}
                   <h3>{% trans "Photos of Past Events" %}</h3>
                   <div class="past-photos">
                     {% for photo in hazard.photos %}

--- a/disasterinfosite/translation.py
+++ b/disasterinfosite/translation.py
@@ -1,7 +1,7 @@
 # Uncomment if you want to translate Django models.
 
 # from modeltranslation.translator import register, translator, TranslationOptions
-# from .models import SiteSettings, Location, SupplyKit, ImportantLink, ShapefileGroup, PastEventsPhoto, DataOverviewImage
+# from .models import SiteSettings, Location, SupplyKit, ImportantLink, ShapefileGroup, PastEventsPhoto, DataOverviewImage, TextSnugget, SnuggetSection, SnuggetSubSection
 
 # @register(SiteSettings)
 # class SiteSettingsTranslationOptions(TranslationOptions):
@@ -30,3 +30,15 @@
 # @register(DataOverviewImage)
 # class DataOverviewImageTranslationOptions(TranslationOptions):
 #   fields = ('link_text',)
+
+# @register(TextSnugget)
+# class TextSnuggetTranslationOptions(TranslationOptions):
+#   fields = ('content',)
+
+# @register(SnuggetSection)
+# class SunggetSectionTranslationOptions(TranslationOptions):
+#   fields = ('display_name',)
+
+# @register(SnuggetSubSection)
+# class SunggetSubSectionTranslationOptions(TranslationOptions):
+#   fields = ('display_name',)


### PR DESCRIPTION
This makes snugget sections and subsections behave more like shapefile groups, in that you can name them whatever you want in the spreadsheet, but their display names are configurable in Django Admin.

So if we decide we want "OLD STUFF" instead of "In Recent History", we don't have to do a whole new snugget reload.