### PR TITLE
Removed outdated references to SnuggetSubSection

### DIFF
--- a/disasterinfosite/admin.py
+++ b/disasterinfosite/admin.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 # GENERATED CODE GOES HERE
 # DO NOT MANUALLY EDIT CODE IN THIS SECTION - IT WILL BE OVERWRITTEN
 # adminModelImports
-from .models import EmbedSnugget, TextSnugget, SnuggetSection, SnuggetSubSection, Location, SiteSettings, SupplyKit, ImportantLink
+from .models import EmbedSnugget, TextSnugget, SnuggetSection, Location, SiteSettings, SupplyKit, ImportantLink
 # END OF GENERATED CODE BLOCK
 ######################################################
 from .models import ShapefileGroup, PastEventsPhoto, DataOverviewImage, UserProfile

--- a/import.py
+++ b/import.py
@@ -24,7 +24,7 @@ def main():
   modelsFilters = ""
   modelsGeoFilters = ""
   modelsSnuggetRatings = ""
-  adminModelImports = "from .models import EmbedSnugget, TextSnugget, SnuggetSection, SnuggetSubSection, Location, SiteSettings, SupplyKit, ImportantLink"
+  adminModelImports = "from .models import EmbedSnugget, TextSnugget, SnuggetSection, Location, SiteSettings, SupplyKit, ImportantLink"
   adminFilterRefs = ""
   adminSiteRegistrations = ""
   loadMappings = ""


### PR DESCRIPTION
Minor change here, just making it match the other recent changes to the structure.  I was getting Python errors complaining that it can't import `SnuggetSubSection`.