### PR TITLE
Expandable versus non-expandable sections

### DIFF
--- a/disasterinfosite/migrations/0001_initial.py
+++ b/disasterinfosite/migrations/0001_initial.py
@@ -126,7 +126,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('name', models.CharField(max_length=50)),
                 ('display_name', models.CharField(default="", help_text='The name to show for this section', max_length=50)),
-                ('expands', models.BooleanField(default=True, help_text='Whether this section is able to be clicked on and expanded')),
+                ('collapsible', models.BooleanField(default=True, help_text='Whether this section of the data is collapsible')),
                 ('order_of_appearance', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the tab. 0 is at the top."))
             ],
         ),

--- a/disasterinfosite/migrations/0001_initial.py
+++ b/disasterinfosite/migrations/0001_initial.py
@@ -126,6 +126,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, verbose_name='ID', auto_created=True, serialize=False)),
                 ('name', models.CharField(max_length=50)),
                 ('display_name', models.CharField(default="", help_text='The name to show for this section', max_length=50)),
+                ('expands', models.BooleanField(default=True, help_text='Whether this section is able to be clicked on and expanded')),
                 ('order_of_appearance', models.IntegerField(default=0, help_text="The order in which you'd like this to appear in the tab. 0 is at the top."))
             ],
         ),

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -231,6 +231,7 @@ class SnuggetType(models.Model):
 class SnuggetSection(models.Model):
     name = models.CharField(max_length=50)
     display_name = models.CharField(max_length=50, help_text="The name to show for this section", default="")
+    expands = models.BooleanField(default=True, help_text="Whether this section is able to be clicked on and expanded")
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the tab. 0 is at the top."

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -231,7 +231,7 @@ class SnuggetType(models.Model):
 class SnuggetSection(models.Model):
     name = models.CharField(max_length=50)
     display_name = models.CharField(max_length=50, help_text="The name to show for this section", default="")
-    expands = models.BooleanField(default=True, help_text="Whether this section is able to be clicked on and expanded")
+    collapsible = models.BooleanField(default=True, help_text='Whether this section of the data is collapsible')
     order_of_appearance = models.IntegerField(
         default=0,
         help_text="The order in which you'd like this to appear in the tab. 0 is at the top."

--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from django.contrib.auth.models import User
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import Point
@@ -278,11 +279,8 @@ class Snugget(models.Model):
     @staticmethod
     def findSnuggetsForPoint(lat=0, lng=0, merge_deform = True):
         pnt = Point(lng, lat)
-        groups = ShapefileGroup.objects.all()
-        groupsDict = {}
-
-        for group in groups:
-            groupsDict[group] = []
+        groups = ShapefileGroup.objects.all().order_by('order_of_appearance')
+        groupsDict = OrderedDict({el:[] for el in groups})
 
 ######################################################
 # GENERATED CODE GOES HERE
@@ -290,7 +288,7 @@ class Snugget(models.Model):
 # modelsGeoFilters
 # END OF GENERATED CODE BLOCK
 ######################################################
-
+        return groupsDict
 
 
     def __str__(self):

--- a/disasterinfosite/static/js/app.js
+++ b/disasterinfosite/static/js/app.js
@@ -100,19 +100,6 @@ function submitLocation(lat, lng, queryText) {
   }
 }
 
-// Set up slick photo slideshow
-// TODO: this may work differently once there are multiple slideshows on a page
-function loadGallery() {
-  var currentSlideElement = $(".section-content .past-photos");
-  currentSlideElement.slick({
-    slidesToShow: 1,
-    variableWidth: true,
-    prevArrow: '<button type="button" class="slick-prev"></button>',
-    nextArrow: '<button type="button" class="slick-next"></button>'
-  });
-  return currentSlideElement;
-}
-
 $(document).ready(function() {
   // grab the position, if possible
   var query_lat = getURLParameter("lat");
@@ -271,21 +258,30 @@ $(document).ready(function() {
     $(".loading").hide();
   }
 
-  // Set up expanding and collapsing sections
+  // Set up expanding and collapsing sections. Set up slideshow
+  // in applicable sections when they are expanded.
+  var collapseSectionClass = "section-content--collapse";
+
   $(".section-title--collapse").on("click", function(event) {
     var contentSectionId = $(event.target).data("section");
     if (contentSectionId) {
-      $("#" + contentSectionId).toggleClass("section-content--collapse");
+      var $contentSection = $("#" + contentSectionId);
+      var $currentSlideElement = $("#" + contentSectionId + " .past-photos");
+
+      if ($contentSection.hasClass(collapseSectionClass)) {
+        $contentSection.removeClass(collapseSectionClass);
+        if ($currentSlideElement) {
+          $currentSlideElement.slick({
+            slidesToShow: 1,
+            variableWidth: true
+          });
+        }
+      } else {
+        $contentSection.addClass(collapseSectionClass);
+        if ($currentSlideElement) {
+          $currentSlideElement.slick("unslick");
+        }
+      }
     }
-  });
-
-  // Initialize the slide gallery on the open disaster tab
-  var slideContainer = loadGallery();
-
-  // Open a new image gallery when a new tab is opened
-  // todo: This will need to be modified to work with opening and closing sections
-  $(".disaster-tabs").on("toggled", function() {
-    slideContainer.slick("unslick");
-    slideContainer = loadGallery();
   });
 });

--- a/disasterinfosite/static/js/app.js
+++ b/disasterinfosite/static/js/app.js
@@ -271,6 +271,14 @@ $(document).ready(function() {
     $(".loading").hide();
   }
 
+  // Set up expanding and collapsing sections
+  $(".section-title--collapse").on("click", function(event) {
+    var contentSectionId = $(event.target).data("section");
+    if (contentSectionId) {
+      $("#" + contentSectionId).toggleClass("section-content--collapse");
+    }
+  });
+
   // Initialize the slide gallery on the open disaster tab
   var slideContainer = loadGallery();
 

--- a/disasterinfosite/static/style/app.scss
+++ b/disasterinfosite/static/style/app.scss
@@ -555,8 +555,12 @@ form:invalid {
 }
 
 /* Sections */
+.section-title--static {
+  color: $soft-black;
+}
 
-.section-content {
+.section-content--collapse {
+  display: none;
 }
 
 /* Snugget content */

--- a/disasterinfosite/static/style/app.scss
+++ b/disasterinfosite/static/style/app.scss
@@ -559,8 +559,19 @@ form:invalid {
   color: $soft-black;
 }
 
+.section-title--collapse {
+  cursor: pointer;
+}
+
+.section-content {
+  max-height: 9000px;
+  overflow: auto;
+  transition: max-height 0.3s ease-in-out;
+}
+
 .section-content--collapse {
-  display: none;
+  max-height: 0;
+  overflow: hidden;
 }
 
 /* Snugget content */

--- a/disasterinfosite/static/style/app.scss
+++ b/disasterinfosite/static/style/app.scss
@@ -566,7 +566,7 @@ form:invalid {
 .section-content {
   max-height: 9000px;
   overflow: auto;
-  transition: max-height 0.3s ease-in-out;
+  transition: max-height 0.3s ease-out;
 }
 
 .section-content--collapse {

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -7,9 +7,9 @@
     <h1><span class="info__header">{% trans "What to expect for" %}</span> <span class="info__location">{{ location_name }}</span></h1>
     <div class="info__start-over">
       <a class="link--grey" href="{{ settings.site_url }}">
-      {% trans "Wrong address? Start over" %}
-    </a>
-  </div>
+        {% trans "Wrong address? Start over" %}
+      </a>
+    </div>
   </div>
 {% endblock info-instructions %}
 

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -18,10 +18,10 @@
     <div class="disaster-container" id="{{group.name}}">
       <h2 class="link--grey">{{group.display_name}}</h2>
         <div class="disaster-content">
-        {% for section, snuggets in hazard.sections.items %}
+        {% for section, snuggets in hazard.items %}
           <h4>{{ section.name }}</h4>
           <div class="section-content" id="{{group.name}}-{{section.name}}">
-            {% for snugget in snuggets %}
+            {% for snugget in snuggets|dictsort:"order" %}
               {% show_snugget snugget %}
             {% endfor %}
           </div>

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -19,7 +19,7 @@
       <h2 class="link--grey">{{group.display_name}}</h2>
         <div class="disaster-content">
         {% for section, snuggets in hazard.items %}
-          {% if section.expands %}
+          {% if section.collapsible %}
           <h4 class="section-title section-title--collapse link--grey" data-section="{{group.name}}-{{section.name|slugify}}">{{ section.name }}</h4>
           <div class="section-content section-content--collapse" id="{{group.name}}-{{section.name|slugify}}">
           {% else %}

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -19,8 +19,13 @@
       <h2 class="link--grey">{{group.display_name}}</h2>
         <div class="disaster-content">
         {% for section, snuggets in hazard.items %}
-          <h4>{{ section.name }}</h4>
-          <div class="section-content" id="{{group.name}}-{{section.name}}">
+          {% if section.expands %}
+          <h4 class="section-title section-title--collapse link--grey">{{ section.name }}</h4>
+          <div class="section-content section-content--collapse" id="{{group.name}}-{{section.name|slugify}}">
+          {% else %}
+          <h4 class="section-title section-title--static">{{ section.name }}</h4>
+          <div class="section-content">
+          {% endif %}
             {% for snugget in snuggets|dictsort:"order" %}
               {% show_snugget snugget %}
             {% endfor %}

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -20,7 +20,7 @@
         <div class="disaster-content">
         {% for section, snuggets in hazard.items %}
           {% if section.expands %}
-          <h4 class="section-title section-title--collapse link--grey">{{ section.name }}</h4>
+          <h4 class="section-title section-title--collapse link--grey" data-section="{{group.name}}-{{section.name|slugify}}">{{ section.name }}</h4>
           <div class="section-content section-content--collapse" id="{{group.name}}-{{section.name|slugify}}">
           {% else %}
           <h4 class="section-title section-title--static">{{ section.name }}</h4>

--- a/disasterinfosite/templates/no_content_found.html
+++ b/disasterinfosite/templates/no_content_found.html
@@ -1,30 +1,22 @@
 {% extends "index.html" %}
 {% load i18n %}
 
- {% block info-instructions %}
+{% block info-instructions %}
   <div class="information-container">
-    <div class="information-instructions" role="complementary">
-        <p class="location-instructions">
-          {% trans "Give a location by typing in the box below, clicking on the map, or clicking 'find me'. You'll get a personalized report on your natural hazard risks and steps you can take to prepare." %}
-        </p>
+    <h1><span class="info__header">{% trans "No information available for" %}</span> <span class="info__location">{{ location_name }}</span></h1>
+    <div class="info__start-over">
+      <a class="link--grey" href="{{ settings.site_url }}">
+        {% trans "Wrong address? Start over" %}
+      </a>
     </div>
   </div>
 {% endblock info-instructions %}
 
-{% block map %}
-  <div role="application">
-    <div id="map"></div>
-  </div>
-{% endblock map %}
-
-
 {% block main-content %}
-  <div role="main">
-    <h2 class="caps">{% trans "No information available." %}</h2>
+  <div class="disaster-container">
+    <h2 class="link--grey">{% trans "No information available." %}</h2>
     <p>
       {% blocktrans with area_name=location.area_name %}It looks like your location is outside of {{ area_name }}.{% endblocktrans %}
-    </p>
-    <p>
       {% trans "While we value and promote resilience everywhere, the data that powers this site isn't available for other places yet." %}
     </p>
   </div>

--- a/disasterinfosite/views.py
+++ b/disasterinfosite/views.py
@@ -138,7 +138,7 @@ def app_view(request):
                             else:
                                 data[group][snugget.section].append(snugget)
 
-
+                    # Sort the sections by order_of_appearance
                     data[group] = OrderedDict(sorted(data[group].items(), key=lambda t: t[0].order_of_appearance))
 
             renderData['data'] = data

--- a/import.py
+++ b/import.py
@@ -89,9 +89,8 @@ def main():
   modelsLocationsList = modelsLocationsList.strip(",\n") + "\n"
 
   # assemble the whole return statement for the snugget class after going through the loop
-  modelsSnuggetReturns = "        return {'groups': groupsDict,\n"
-  modelsSnuggetReturns += modelsSnuggetRatings.strip(",\n") + "\n"
-  modelsSnuggetReturns += "                }\n"
+  modelsSnuggetReturns = "        return groupsDict\n"
+
 
   # make sure this gets its own line of code
   adminModelImports += "\n"
@@ -321,7 +320,7 @@ def modelsGeoFilterGen(stem, keyField):
   text  = "        qs_" + stem + " = " + stem + ".objects.filter(geom__contains=pnt)\n"
   text += "        " + stem + "_rating = " + "qs_" + stem + ".values_list('" + keyField.lower() + "', flat=True)\n"
   text += "        for rating in " + stem + "_rating:\n"
-  text += "            individualSnugget = Snugget.objects.filter(" + stem + "_filter__" + keyField.lower() + "__exact=rating).select_subclasses()\n"
+  text += "            individualSnugget = Snugget.objects.filter(" + stem + "_filter__" + keyField.lower() + "__exact=rating).order_by('order').select_subclasses()\n"
   text += "            if individualSnugget:\n"
   text += "                groupsDict[individualSnugget[0].group].extend(individualSnugget)\n\n"
   return text


### PR DESCRIPTION
This change adds an option in Django-admin to check a box on a snugget section that makes it into one of the expandable ones:

![image](https://user-images.githubusercontent.com/547883/55038806-4aa2df00-4fdf-11e9-812f-b20299f064e3.png)


![image](https://user-images.githubusercontent.com/547883/55038790-3ced5980-4fdf-11e9-9b14-c56c7c57a967.png)


Pages with results now look like this. You can click on the blue headers to expand them:

![image](https://user-images.githubusercontent.com/547883/55038714-01eb2600-4fdf-11e9-9c1a-34d74146ee65.png)


![image](https://user-images.githubusercontent.com/547883/55038743-1c250400-4fdf-11e9-8b0d-18c2ae53adf9.png)
