### PR TITLE
Add a caret for the expanding sections; popout mobile fix

### DIFF
--- a/disasterinfosite/models.py
+++ b/disasterinfosite/models.py
@@ -247,6 +247,11 @@ class SnuggetPopOut(models.Model):
     alt_text = models.TextField(default='', max_length=255)
     video = EmbedVideoField(null=True)
 
+    @property
+    def has_content(self):
+        "Returns true if this popout has some content"
+        return (self.text or self.image or self.link or self.video)
+
     def __str__(self):
         return self.text[:100]
 

--- a/disasterinfosite/static/img/caret.svg
+++ b/disasterinfosite/static/img/caret.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+    <title>Artboard</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="baseline-arrow_forward_ios-24px" transform="translate(12.000000, 12.000000) rotate(-270.000000) translate(-12.000000, -12.000000) ">
+            <polygon id="Path" fill="#106edf" fill-rule="nonzero" points="5.88 4.12 13.76 12 5.88 19.88 8 22 18 12 8 2"></polygon>
+            <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+        </g>
+    </g>
+</svg>

--- a/disasterinfosite/static/js/app.js
+++ b/disasterinfosite/static/js/app.js
@@ -14,6 +14,7 @@ require("../img/thinking.gif");
 require("../img/logo.png");
 require("../img/logo-no-text.png");
 require("../img/icon-search.png");
+require("../img/caret.svg");
 
 require("./users");
 require("slick-carousel");
@@ -261,15 +262,20 @@ $(document).ready(function() {
   // Set up expanding and collapsing sections. Set up slideshow
   // in applicable sections when they are expanded.
   var collapseSectionClass = "section-content--collapse";
+  var caretUpClass = "caret--up";
 
   $(".section-title--collapse").on("click", function(event) {
-    var contentSectionId = $(event.target).data("section");
+    var $sectionTitle = $(event.delegateTarget);
+    var contentSectionId = $sectionTitle.data("section");
     if (contentSectionId) {
       var $contentSection = $("#" + contentSectionId);
+      var $titleCaret = $sectionTitle.find(".caret");
       var $currentSlideElement = $("#" + contentSectionId + " .past-photos");
 
       if ($contentSection.hasClass(collapseSectionClass)) {
         $contentSection.removeClass(collapseSectionClass);
+        $titleCaret.addClass(caretUpClass);
+
         if ($currentSlideElement) {
           $currentSlideElement.slick({
             slidesToShow: 1,
@@ -278,6 +284,7 @@ $(document).ready(function() {
         }
       } else {
         $contentSection.addClass(collapseSectionClass);
+        $titleCaret.removeClass(caretUpClass);
         if ($currentSlideElement) {
           $currentSlideElement.slick("unslick");
         }

--- a/disasterinfosite/static/style/app.scss
+++ b/disasterinfosite/static/style/app.scss
@@ -592,6 +592,7 @@ form:invalid {
 }
 
 .section-title--collapse {
+  display: flex; // Fold caret aside wrapped text nicely on smaller sizes
   border-bottom: 2px solid $light-grey;
   cursor: pointer;
 }

--- a/disasterinfosite/static/style/app.scss
+++ b/disasterinfosite/static/style/app.scss
@@ -596,6 +596,20 @@ form:invalid {
   cursor: pointer;
 }
 
+.caret {
+  vertical-align: middle;
+  margin-right: 10px;
+}
+
+.caret--up {
+  -moz-transform: scaleY(-1);
+  -o-transform: scaleY(-1);
+  -webkit-transform: scaleY(-1);
+  transform: scaleY(-1);
+  filter: FlipV;
+  -ms-filter: "FlipV";
+}
+
 .section-content {
   display: flex;
   flex-direction: column;

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -59,7 +59,9 @@
             </div>
             <div class="snugget__popout">
             {% for snugget in snuggets|dictsort:"order" %}
-              {% include "pop_out.html" %}
+              {% if snugget.photos or snugget.pop_out.has_content %}
+                {% include "pop_out.html" %}
+              {% endif %}
             {% endfor %}
             </div>
           </div>

--- a/disasterinfosite/templates/found_content.html
+++ b/disasterinfosite/templates/found_content.html
@@ -1,6 +1,8 @@
 {% extends "index.html" %}
 {% load i18n %}
 {% load show_snugget %}
+{% load webpack_static from webpack_loader %}
+
 
 {% block info-instructions %}
   <div class="information-container">
@@ -43,7 +45,7 @@
         {% for section, snuggets in hazard.items %}
           {% if section.collapsible %}
           <h4 class="section-title section-title--collapse" data-section="{{group.name}}-{{section.name|slugify}}">
-            {{ section.name }}
+            <img class="caret" src="{% webpack_static 'build/caret.svg' %}" alt="">{{ section.name }}
           </h4>
           <div class="section-content section-content--collapse" id="{{group.name}}-{{section.name|slugify}}">
           {% else %}

--- a/disasterinfosite/templates/pop_out.html
+++ b/disasterinfosite/templates/pop_out.html
@@ -1,7 +1,7 @@
 {% load embed_video_tags %}
 
 {% block popout-content %}
-
+<div class="popout-content">
   {% if snugget.pop_out.link %}
     <a href="{{snugget.pop_out.link}}" target="_blank">
   {% endif %}
@@ -30,8 +30,8 @@
 
   {% endif %}
 
-<!-- Right now all photo slideshows are in the popout section. If we want to have both, we'll need to make something like pop_out_image_folder in the snuggets file. -->
   {% if snugget.photos %}
+  <!-- Right now all photo slideshows are in the popout section. If we want to have both, we'll need to make something like pop_out_image_folder in the snuggets file. -->
     <div class="past-photos">
     {% for photo in snugget.photos %}
     <div class="past-photo__container">
@@ -39,8 +39,8 @@
        <div class="past-photo__caption">{{ photo.caption }}</div>
      </div>
     {% endfor %}
-  </div>
+    </div>
   {% endif %}
-
+</div>
 {% endblock %}
 


### PR DESCRIPTION
This adds a caret for expanding and collapsing sections"
small:
![image](https://user-images.githubusercontent.com/547883/55508279-6a08c000-560e-11e9-8355-1380f7195e6d.png)

medium:
![image](https://user-images.githubusercontent.com/547883/55508251-5a897700-560e-11e9-8333-2a9a9757a8b2.png)

large:
![image](https://user-images.githubusercontent.com/547883/55508300-7a209f80-560e-11e9-80c3-f2b9d710df33.png)

It also fixes a bug that was introduced in the last pull request. Since popouts got a border on small sizes, it meant that empty popouts were making teal rectangles show up all over the place, because they had borders, but no content. This changes adds a method to the popout model to ask the popout whether it has content, so that we can choose not to render them if they are empty.
