### PR TITLE
Update references for model translation

### DIFF
--- a/disasterinfosite/settings.py
+++ b/disasterinfosite/settings.py
@@ -70,14 +70,17 @@ LOCALE_PATHS = [os.path.join(BASE_DIR, 'locale')]
 LANGUAGE_CODE = 'en'
 USE_L10N = True
 
-# If you're translating this site, add the languages you're translating to here.w
+# If you're translating this site, add the languages you're translating to here.
 gettext = lambda s: s
 LANGUAGES = (
     ('en', gettext('English')),
     ('es', gettext('Spanish'))
 )
 
-MODELTRANSLATION_DEFAULT_LANGUAGE = 'en'
+# If you have only one language beside English, this trailing comma is important.
+# Leave English out of this list to not have extra fields in Django Admin.
+MODELTRANSLATION_LANGUAGES = ('es',)
+
 USE_I18N = True
 TIME_ZONE = 'UTC'
 USE_TZ = True

--- a/disasterinfosite/translation.py
+++ b/disasterinfosite/translation.py
@@ -1,7 +1,7 @@
-# Uncomment if you want to translate Django models.
+# Uncomment if you want to translate Django models. You will need to make migrations and migrate after doing this.
 
 # from modeltranslation.translator import register, translator, TranslationOptions
-# from .models import SiteSettings, Location, SupplyKit, ImportantLink, ShapefileGroup, PastEventsPhoto, DataOverviewImage, TextSnugget, SnuggetSection, SnuggetSubSection
+# from .models import SiteSettings, Location, SupplyKit, ImportantLink, ShapefileGroup, PastEventsPhoto, DataOverviewImage, TextSnugget, EmbedSnugget, SlideshowSnugget, SnuggetPopOut, SnuggetSection
 
 # @register(SiteSettings)
 # class SiteSettingsTranslationOptions(TranslationOptions):
@@ -35,10 +35,18 @@
 # class TextSnuggetTranslationOptions(TranslationOptions):
 #   fields = ('content',)
 
-# @register(SnuggetSection)
-# class SunggetSectionTranslationOptions(TranslationOptions):
-#   fields = ('display_name',)
+# @register(EmbedSnugget)
+# class EmbedSnuggetTranslationOptions(TranslationOptions):
+#   fields = ('text',)
 
-# @register(SnuggetSubSection)
-# class SunggetSubSectionTranslationOptions(TranslationOptions):
+# @register(SlideshowSnugget)
+# class SlideshowSnuggetTranslationOptions(TranslationOptions):
+#   fields = ('text',)
+
+# @register(SnuggetPopOut)
+# class SnuggetPopOutTranslationOptions(TranslationOptions):
+#   fields = ('text', 'alt_text')
+
+# @register(SnuggetSection)
+# class SnuggetSectionTranslationOptions(TranslationOptions):
 #   fields = ('display_name',)


### PR DESCRIPTION
Since the classes in `models.py` changed, the classes in `translation.py` also need to change. I hadn't caught that before because I hadn't turned on the parts for.translating the site yet.