### PR TITLE
Add dummy location conf to make language redirects work properly in prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       - html:/usr/share/nginx/html
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - type: bind
+        source: ./empty.conf
+        target: /etc/nginx/vhost.d/${VIRTUAL_HOST_A}_location
+      - type: bind
+        source: ./empty.conf
+        target: /etc/nginx/vhost.d/${VIRTUAL_HOST_B}_location
+      - type: bind
         source: ./missoula_proxy.conf
         target: /etc/nginx/vhost.d/$VIRTUAL_HOST_A
       - type: bind


### PR DESCRIPTION
This was broken in prod but not test - using the language switching feature would result in a redirect from something like `hazardready.org/seattle/en` to `hazardready.org/cn`

I noticed that the nginx-proxy container on test had `VIRTUAL_HOST`_location config files in /etc/nginx/vhost.d for some reason, while prod did not. I think this might be a side effect of running in a subdomain. At any rate, `*_location` was mostly a set of zero-byte files except where the redirect from `/missoula` to `/montana` was specified. So I made it so that during setup, nginx-proxy gets a set of zero-byte files for those things whether it thinks it needs them or not.

I don't know a huge amount about nginx config but it did fix the problem.